### PR TITLE
Add Aria: Loading Spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 - **LinkAria** - Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label.
 
-- **LoadingAria** - Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. If the loading indicator is visible, set `aria-busy` to `true`. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed.
+- **LoadingAria** - Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed.
 
 - **RadioAria** - Add `role='radio'` to a checkable interactive control. Use radio in place of checkbox if only one item in a group can be checked. Add `aria-checked` to indicate the state of the checkbox.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
 
 - **LinkAria** - Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label.
 
+- **LoadingAria** - Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. If the loading indicator is visible, set `aria-busy` to `true`. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed.
+
 - **RadioAria** - Add `role='radio'` to a checkable interactive control. Use radio in place of checkbox if only one item in a group can be checked. Add `aria-checked` to indicate the state of the checkbox.
 
 - **SliderAria** - Add `role='slider'` to allow users to select from a certain range. Add `aria-orientation` to indicate what direction the slider is oriented in. Add `aria-valuemin` to indicate the minimum value. Add `aria-valuemax` to indicate the maximum value. Add `aria-valuenow` to indicate the current value. If the value is not represented by a number add `aria-valuetext` in place of aria-valuenow.

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -123,6 +123,18 @@
         ],
         "description": "Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label."
     },
+    "LoadingAria": {
+        "prefix": [
+            "LoadingAria",
+        ],
+        "body": [
+            "role='status'", // Live region role with an implicit aria-live value of polite that notifies assistive technology when content has been updated. Must be present in the DOM before the loading indicator has rendered.
+            "aria-live='polite'", // Used in conjunction with live region role of status for better assistive technology support.
+            "aria-label='Loading'", // Defines the accessible name of the loading indicator if copy is not provided.
+            "aria-busy='$1'", // Boolean value that should be true while loading indicator is present. 
+        ],
+        "description": "Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. If the loading indicator is visible, set `aria-busy` to `true`. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed."
+    },
     "RadioAria": {
         "prefix": [
             "RadioAria",

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -131,9 +131,8 @@
             "role='status'", // Live region role with an implicit aria-live value of polite that notifies assistive technology when content has been updated. Must be present in the DOM before the loading indicator has rendered.
             "aria-live='polite'", // Used in conjunction with live region role of status for better assistive technology support.
             "aria-label='Loading'", // Defines the accessible name of the loading indicator if copy is not provided.
-            "aria-busy='$1'", // Boolean value that should be true while loading indicator is present. 
         ],
-        "description": "Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. If the loading indicator is visible, set `aria-busy` to `true`. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed."
+        "description": "Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed."
     },
     "RadioAria": {
         "prefix": [


### PR DESCRIPTION
# What Changed
 
- Added `LoadingAria` snippet (includes `role="status"`, `aria-live="polite"`, `aria-label="Loading"` and `aria-busy` attributes
-  Updated README.md to include this PR's changes


# Why
For issue: https://github.com/intuit/accessibility-snippets/issues/32

Provide guidance on aria attributes needed for loading spinners and indicators.

Todo:
- [x] Add Semantic Version Label 
- [ ] Add tests
- [x] Add docs
