### PR TITLE
fixed Add Aria: separator#31

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 
 - **RadioAria** - Add `role='radio'` to a checkable interactive control. Use radio in place of checkbox if only one item in a group can be checked. Add `aria-checked` to indicate the state of the checkbox.
 
+- **SeperatorAria** - Add `role='separator'` to a HR tag.Add `aria-valuemin` to indicate the minimum value. Add `aria-valuemax` to indicate the maximum value. Add `aria-valuenow` to indicate the current value. There are set default values 0. 100 and 50 respectively and can be modified. Setting `aria-seperator` automatically sets aria-orientation = 'horizontal'.
+
 - **SliderAria** - Add `role='slider'` to allow users to select from a certain range. Add `aria-orientation` to indicate what direction the slider is oriented in. Add `aria-valuemin` to indicate the minimum value. Add `aria-valuemax` to indicate the maximum value. Add `aria-valuenow` to indicate the current value. If the value is not represented by a number add `aria-valuetext` in place of aria-valuenow.
 
 - **SwitchAria** - Use `role='switch'` on checkboxes that represent an 'on' or 'off' state. Add `aria-checked` to indicate whether component is on or off. Add `aria-required` if the field is required.

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -49,6 +49,16 @@
         ],
         "description": "Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed."
     },
+    "ImageAria": {
+        "prefix": [
+            "ImageAria",
+        ],
+        "body": [
+            "role='img'",
+            "aria-label='$1'", // May be replaced with aria-labelledby if descriptive text is provide in another element within the role.
+        ],
+        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
+    },
     "ArticleAria": {
         "prefix": [
             "ArticleAria",
@@ -123,6 +133,17 @@
         ],
         "description": "Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label."
     },
+    "LoadingAria": {
+        "prefix": [
+            "LoadingAria",
+        ],
+        "body": [
+            "role='status'", // Live region role with an implicit aria-live value of polite that notifies assistive technology when content has been updated. Must be present in the DOM before the loading indicator has rendered.
+            "aria-live='polite'", // Used in conjunction with live region role of status for better assistive technology support.
+            "aria-label='Loading'", // Defines the accessible name of the loading indicator if copy is not provided.
+        ],
+        "description": "Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed."
+    },
     "RadioAria": {
         "prefix": [
             "RadioAria",
@@ -196,6 +217,20 @@
         ],
         "description":"Add `role='timer'` to indicate to assistive technologies that an element is a numerical counter listing the amount of elapsed time from a starting point or the remaining time until an end point. Add `aria-label` to provide the name of the timer. Add `aria-live` to explicitly denote a live region (Elements with the role timer have an implicit aria-live value of off). Add `aria-describedby` to indicate the idref of an element that contains additional instructions for navigating or operating this element. Add `aria-roledescription` o give the timer a more descriptive role text for screen readers to speak. Add `aria-atomic` to set whether or not the screen reader should always present the live region as a whole, even if only part of the region changes."
     },
+    "CellAria": {
+        "prefix": [
+            "CellAria",
+        ],
+        "body": [
+            "role='cell'",
+            "aria-colspan={$1}",
+            "aria-rowspan={$2}",
+            "aria-colindex={$3}",
+            "aria-rowindex={$4}",
+            ""
+        ],
+        "description": "Adds `role='cell'` aria attributes for a cell. A cell is identified as an element in a tabular container that does not contain column or row header information. “cells” are only valid within a construct that simulates a standard data table."
+    },
     "SwitchAria": {
         "prefix": [
             "SwitchAria",
@@ -207,6 +242,23 @@
             ""
         ],
         "description": "Use `role='switch'` on checkboxes that represent an 'on' or 'off' state. Add `aria-checked` to indicate whether component is on or off. Add `aria-required` if the field is required."
+    },
+    "SearchboxAria" : {
+        "prefix": [
+            "SearchboxAria"
+        ],
+        "body": [
+            "role='searchbox'",
+            "aria-activedescendant='$1'",
+            "aria-multiline={$2}",
+            "aria-required={$3}",
+            "aria-readonly={$4}",
+            "aria-labelledby='$5'",
+            "aria-placeholder='$6'",
+            "aria-autocomplete='$7'",
+            ""
+        ],
+        "description": "Add `role='searchbox'` to a textbox intended for specifying search criteria."
     },
     "SeparatorAria": {
         "prefix": [
@@ -221,5 +273,5 @@
             ""
         ],
         "description": "Add `role='separator'` to a HR tag. Setting role='separator' automatically sets aria-orientation = 'horizontal'."
-    }
+    },
 }

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -123,17 +123,6 @@
         ],
         "description": "Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label."
     },
-    "LoadingAria": {
-        "prefix": [
-            "LoadingAria",
-        ],
-        "body": [
-            "role='status'", // Live region role with an implicit aria-live value of polite that notifies assistive technology when content has been updated. Must be present in the DOM before the loading indicator has rendered.
-            "aria-live='polite'", // Used in conjunction with live region role of status for better assistive technology support.
-            "aria-label='Loading'", // Defines the accessible name of the loading indicator if copy is not provided.
-        ],
-        "description": "Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed."
-    },
     "RadioAria": {
         "prefix": [
             "RadioAria",
@@ -218,5 +207,19 @@
             ""
         ],
         "description": "Use `role='switch'` on checkboxes that represent an 'on' or 'off' state. Add `aria-checked` to indicate whether component is on or off. Add `aria-required` if the field is required."
+    },
+    "SeparatorAria": {
+        "prefix": [
+            "SeparatorAria"
+        ],
+        "body": [
+            "role='separator'",
+            "aria-orientation = 'horizontal'",
+            "aria-valuemax={${1:0}}",
+            "aria-valuemin={${2:100}}",
+            "aria-valuenow={${3:50}}",
+            ""
+        ],
+        "description": "Add `role='separator'` to a HR tag. Setting role='separator' automatically sets aria-orientation = 'horizontal'."
     }
 }

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -49,16 +49,6 @@
         ],
         "description": "Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed."
     },
-    "ImageAria": {
-        "prefix": [
-            "ImageAria",
-        ],
-        "body": [
-            "role='img'",
-            "aria-label='$1'", // May be replaced with aria-labelledby if descriptive text is provide in another element within the role.
-        ],
-        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
-    },
     "ArticleAria": {
         "prefix": [
             "ArticleAria",
@@ -206,20 +196,6 @@
         ],
         "description":"Add `role='timer'` to indicate to assistive technologies that an element is a numerical counter listing the amount of elapsed time from a starting point or the remaining time until an end point. Add `aria-label` to provide the name of the timer. Add `aria-live` to explicitly denote a live region (Elements with the role timer have an implicit aria-live value of off). Add `aria-describedby` to indicate the idref of an element that contains additional instructions for navigating or operating this element. Add `aria-roledescription` o give the timer a more descriptive role text for screen readers to speak. Add `aria-atomic` to set whether or not the screen reader should always present the live region as a whole, even if only part of the region changes."
     },
-    "CellAria": {
-        "prefix": [
-            "CellAria",
-        ],
-        "body": [
-            "role='cell'",
-            "aria-colspan={$1}",
-            "aria-rowspan={$2}",
-            "aria-colindex={$3}",
-            "aria-rowindex={$4}",
-            ""
-        ],
-        "description": "Adds `role='cell'` aria attributes for a cell. A cell is identified as an element in a tabular container that does not contain column or row header information. “cells” are only valid within a construct that simulates a standard data table."
-    },
     "SwitchAria": {
         "prefix": [
             "SwitchAria",
@@ -245,22 +221,5 @@
             ""
         ],
         "description": "Add `role='separator'` to a HR tag. Setting role='separator' automatically sets aria-orientation = 'horizontal'."
-    },
-    "SearchboxAria" : {
-        "prefix": [
-            "SearchboxAria"
-        ],
-        "body": [
-            "role='searchbox'",
-            "aria-activedescendant='$1'",
-            "aria-multiline={$2}",
-            "aria-required={$3}",
-            "aria-readonly={$4}",
-            "aria-labelledby='$5'",
-            "aria-placeholder='$6'",
-            "aria-autocomplete='$7'",
-            ""
-        ],
-        "description": "Add `role='searchbox'` to a textbox intended for specifying search criteria."
     }
 }


### PR DESCRIPTION
# What Changed
Added snippet for separator

# Why
fixes Add Aria: separator#31
fixes: #31 
easy properties with the default value for separator role for HR tag!

Todo:
- [ ] Add Semantic Version Label 
- [X] Add tests/ Tested
- [X] Add docs
