### PR TITLE
Add Aria: Image Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 - **FeedAria** - Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed.
 
-- **ImageAria** - Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` be replaced with `aria-labelledby` if descriptive text is provide in another element within the role.
+- **ImageAria** - Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role.
 
 - **LinkAria** - Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
 
 - **FeedAria** - Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed.
 
+- **ImageAria** - Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` be replaced with `aria-labelledby` if descriptive text is provide in another element within the role.
+
 - **LinkAria** - Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label.
 
 - **LoadingAria** - Add `role='status'` and `aria-live='polite'` to element wrapping a loading spinner or indicator. The live region must be present in the DOM before the loading indicator has rendered. Add `aria-label='Loading'` to loading indicator if no other text element or content is passed.

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -57,7 +57,7 @@
             "role='img'",
             "aria-label='$1'", // May be replaced with aria-labelledby if descriptive text is provide in another element within the role.
         ],
-        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
+        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
     },
     "ArticleAria": {
         "prefix": [

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -49,6 +49,16 @@
         ],
         "description": "Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed."
     },
+    "ImageAria": {
+        "prefix": [
+            "ImageAria",
+        ],
+        "body": [
+            "role='img'",
+            "aria-label='$1'", // May be replaced with aria-labelledby if descriptive text is provide in another element within the role.
+        ],
+        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
+    },
     "ArticleAria": {
         "prefix": [
             "ArticleAria",


### PR DESCRIPTION
# What Changed

- Added `ImageAria` snippet (includes `role="img"` and `aria-label` attributes
- Updated README.md to include this PR's changes 

# Why

For issue: https://github.com/intuit/accessibility-snippets/issues/41

Provide guidance on aria attributes needed for role images.

