### PR TITLE
Add Aria: Figure Role

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -78,7 +78,18 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "bolu-tife",
+      "name": "bolu-tife",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59070723?v=4",
+      "profile": "https://github.com/bolu-tife",
+      "contributions": [
+        "doc",
+        "code"
+      ]
     }
   ],
-  "contributorsPerLine": 7
+  
+  "contributorsPerLine": 8
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -78,18 +78,8 @@
         "doc",
         "code"
       ]
-    },
-    {
-      "login": "bolu-tife",
-      "name": "bolu-tife",
-      "avatar_url": "https://avatars.githubusercontent.com/u/59070723?v=4",
-      "profile": "https://github.com/bolu-tife",
-      "contributions": [
-        "doc",
-        "code"
-      ]
     }
   ],
   
-  "contributorsPerLine": 8
+  "contributorsPerLine": 7
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
 
 - **FeedAria** - Add `role='feed'` to a dynamic list of articles. Add `aria-busy` if articles are being loaded or have been removed from the feed.
 
+- **FigureAria** - Add `role='figure'` to identify a figure inside page content where appropriate semantics do not already exist. Add `aria-labelledby` when the text is a concise label. Add `aria-describedby` when the text is a longer description. Add `aria-label` if there is no element containing text that could serve as a label.
+
 - **ImageAria** - Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role.
 
 - **LinkAria** - Add `role='link'` to elements that act as hyperlinks. Ensure the link can be navigated to via the keyboard. If the link role is added to an image add `alt` text. Add an `aria-label` if the link does not provide a descriptive text label.

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -59,6 +59,19 @@
         ],
         "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
     },
+    "FigureAria": {
+        "prefix": [
+            "FigureAria",
+        ],
+        "body": [
+            "role='figure'",
+            "aria-label='$1'",
+            "aria-labelledby='$2'",
+            "aria-describedby='$3'",
+            ""
+        ],
+        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
+    },
     "ArticleAria": {
         "prefix": [
             "ArticleAria",

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -70,7 +70,7 @@
             "aria-describedby='$3'",
             ""
         ],
-        "description": "Add `role='figure'` to identify a figure inside page content where appropriate semantics do not already exist. Elements can be one or more images, code snippets, or other content that puts across information in a different way to a regular flow of text."
+        "description": "Add `role='figure'` to identify a figure inside page content where appropriate semantics do not already exist. Elements can be one or more images, code snippets, or other content that puts across information in a different way to a regular flow of text. Add `aria-labelledby` when the text is a concise label. Add `aria-describedby` when the text is a longer description. Add `aria-label` if there is no element containing text that could serve as a label."
     },
     "ArticleAria": {
         "prefix": [

--- a/snippets/react-snippets.code-snippets
+++ b/snippets/react-snippets.code-snippets
@@ -70,7 +70,7 @@
             "aria-describedby='$3'",
             ""
         ],
-        "description": "Add `role='img'` to identify a set of content as a single image that has multiple elements. Elements can be images, text, emojis or other content that delivers information visually. Add `aria-label` for descriptive alt text for the image. `aria-label` can be replaced with `aria-labelledby` if descriptive text is provide in another element within the role."
+        "description": "Add `role='figure'` to identify a figure inside page content where appropriate semantics do not already exist. Elements can be one or more images, code snippets, or other content that puts across information in a different way to a regular flow of text."
     },
     "ArticleAria": {
         "prefix": [


### PR DESCRIPTION
# What Changed
Added ARIA figure role in react-snippets.code-snippets 

# Why
ARIA figure role was not included in the snippets

Todo:
- [ ]  Add Semantic Version Label 
- [x] Add tests/Tested on local machine
- [x] Add docs
